### PR TITLE
Fix style path imports

### DIFF
--- a/src/assets/jss/material-kit-react/components/buttonStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/buttonStyle.jsx
@@ -6,7 +6,7 @@ import {
   successColor,
   warningColor,
   dangerColor
-} from "../material-kit-react.jsx";
+} from "../../material-kit-react.jsx";
 
 const buttonStyle = {
   button: {

--- a/src/assets/jss/material-kit-react/components/footerStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/footerStyle.jsx
@@ -1,4 +1,4 @@
-import { container, primaryColor } from "../material-kit-react.jsx";
+import { container, primaryColor } from "../../material-kit-react.jsx";
 
 const footerStyle = {
   block: {

--- a/src/assets/jss/material-kit-react/components/headerStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/headerStyle.jsx
@@ -10,7 +10,7 @@ import {
   transition,
   boxShadow,
   drawerWidth
-} from "../material-kit-react.jsx";
+} from "../../material-kit-react.jsx";
 
 const headerStyle = {
   appBar: {

--- a/src/assets/jss/material-kit-react/components/infoStyle.jsx
+++ b/src/assets/jss/material-kit-react/components/infoStyle.jsx
@@ -7,7 +7,7 @@ import {
   roseColor,
   grayColor,
   title
-} from "../material-kit-react.jsx";
+} from "../../material-kit-react.jsx";
 
 const infoStyle = {
   infoArea: {

--- a/src/assets/jss/material-kit-react/views/analyzerPage.jsx
+++ b/src/assets/jss/material-kit-react/views/analyzerPage.jsx
@@ -1,4 +1,4 @@
-import { container, title } from "../material-kit-react.jsx";
+import { container, title } from "../../material-kit-react.jsx";
 
 const landingPageStyle = {
   container: {

--- a/src/assets/jss/material-kit-react/views/landingPageSections/productStyle.jsx
+++ b/src/assets/jss/material-kit-react/views/landingPageSections/productStyle.jsx
@@ -1,4 +1,4 @@
-import { title } from "../../material-kit-react.jsx";
+import { title } from "../../../material-kit-react.jsx";
 
 const productStyle = {
   section: {

--- a/src/assets/jss/material-kit-react/views/landingPageSections/teamStyle.jsx
+++ b/src/assets/jss/material-kit-react/views/landingPageSections/teamStyle.jsx
@@ -1,4 +1,4 @@
-import { cardTitle, title } from "../../material-kit-react.jsx";
+import { cardTitle, title } from "../../../material-kit-react.jsx";
 import imagesStyle from "../../imagesStyles.jsx";
 
 const teamStyle = {

--- a/src/assets/jss/material-kit-react/views/landingPageSections/workStyle.jsx
+++ b/src/assets/jss/material-kit-react/views/landingPageSections/workStyle.jsx
@@ -1,4 +1,4 @@
-import { title } from "../../material-kit-react.jsx";
+import { title } from "../../../material-kit-react.jsx";
 
 const workStyle = {
   section: {


### PR DESCRIPTION
## Summary
- correct path to material-kit-react shared styles for components and views

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find eslint.config.js)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c307535c832fb48bbf5ed0cdf7fa