### PR TITLE
Fix grid justify prop and icon prop types

### DIFF
--- a/src/components/Grid/GridContainer.jsx
+++ b/src/components/Grid/GridContainer.jsx
@@ -15,9 +15,15 @@ const style = {
 };
 
 function GridContainer({ ...props }) {
-  const { classes, children, className, ...rest } = props;
+  const { classes, children, className, justify, ...rest } = props;
+  const gridProps = { ...rest };
+
+  if (justify !== undefined) {
+    gridProps.justifyContent = justify;
+  }
+
   return (
-    <Grid container {...rest} className={classes.grid + " " + className}>
+    <Grid container {...gridProps} className={classes.grid + " " + className}>
       {children}
     </Grid>
   );
@@ -30,7 +36,15 @@ GridContainer.defaultProps = {
 GridContainer.propTypes = {
   classes: PropTypes.object.isRequired,
   children: PropTypes.node,
-  className: PropTypes.string
+  className: PropTypes.string,
+  justify: PropTypes.oneOf([
+    "flex-start",
+    "center",
+    "flex-end",
+    "space-between",
+    "space-around",
+    "space-evenly"
+  ])
 };
 
 export default withStyles(style)(GridContainer);

--- a/src/components/InfoArea/InfoArea.jsx
+++ b/src/components/InfoArea/InfoArea.jsx
@@ -38,7 +38,7 @@ InfoArea.defaultProps = {
 
 InfoArea.propTypes = {
   classes: PropTypes.object.isRequired,
-  icon: PropTypes.func.isRequired,
+  icon: PropTypes.elementType.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
   iconColor: PropTypes.oneOf([


### PR DESCRIPTION
## Summary
- map deprecated `justify` prop to `justifyContent` in GridContainer
- accept `React` element types for icons in InfoArea

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find an eslint.config file due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6856d5c6ca88832f974e1447eda5987f