### PR TITLE
Fix Unicode name decoding

### DIFF
--- a/src/utils/textDecoder.js
+++ b/src/utils/textDecoder.js
@@ -27,14 +27,19 @@ export const decodeUnicodeText = (text) => {
     // 處理可能的 JSON 字符串轉義
     try {
       // 嘗試解析為 JSON 字符串（這會自動處理 Unicode 轉義）
-      const jsonDecoded = JSON.parse(
-        '"' + decodedText.replace(/"/g, '\\"') + '"',
-      );
-      return jsonDecoded;
+      decodedText = JSON.parse('"' + decodedText.replace(/"/g, '\\"') + '"');
     } catch (e) {
-      // 如果 JSON 解析失敗，返回正則表達式處理的結果
-      return decodedText;
+      // 忽略錯誤，保持 decodedText 不變
     }
+
+    // 嘗試解碼可能的多重編碼（例如 UTF-8 以 \u00XX 形式存儲）
+    try {
+      decodedText = decodeURIComponent(escape(decodedText));
+    } catch (e) {
+      // 若失敗則保持原值
+    }
+
+    return decodedText;
   } catch (error) {
     console.warn("Unicode 解碼失敗:", error);
     return text;

--- a/src/views/Analyzer/Sections/UploadSection.jsx
+++ b/src/views/Analyzer/Sections/UploadSection.jsx
@@ -3,10 +3,7 @@ import ReactFileReader from "react-file-reader";
 import Button from "../../../components/CustomButtons/Button.jsx";
 
 // 導入解碼工具
-import {
-  decodeInstagramMessages,
-  containsUnicodeEscapes,
-} from "../../../utils/textDecoder.js";
+import { decodeInstagramMessages } from "../../../utils/textDecoder.js";
 
 import teamStyle from "../../../assets/jss/material-kit-react/views/landingPageSections/teamStyle.jsx";
 import { withStyles } from "@material-ui/core/styles";
@@ -30,24 +27,32 @@ class UploadSection extends React.Component {
     };
 
     const normalizeData = (raw) => {
-      // 先檢查是否需要解碼
-      const rawString = JSON.stringify(raw);
-      let processedData = raw;
+      // 直接對讀取到的資料進行解碼
+      let processedData = decodeInstagramMessages(raw);
 
-      if (containsUnicodeEscapes(rawString)) {
-        console.log("檢測到 Unicode 編碼，正在解碼...");
-        processedData = decodeInstagramMessages(raw);
-        console.log("解碼完成");
-      }
+      const extractNames = (arr) =>
+        (arr || []).map((p) =>
+          typeof p === "string"
+            ? p
+            : p.name || p.username || "",
+        );
 
       if (Array.isArray(processedData)) {
-        return processedData;
+        return processedData.map((rec) => ({
+          ...rec,
+          participants: extractNames(rec.participants),
+        }));
       }
       if (
         processedData.conversation &&
         Array.isArray(processedData.conversation)
       ) {
-        return [processedData];
+        return [
+          {
+            ...processedData,
+            participants: extractNames(processedData.participants),
+          },
+        ];
       }
       if (processedData.messages && Array.isArray(processedData.messages)) {
         const convo = processedData.messages.map((m) => ({
@@ -60,7 +65,7 @@ class UploadSection extends React.Component {
         }));
         return [
           {
-            participants: processedData.participants || [],
+            participants: extractNames(processedData.participants),
             conversation: convo,
           },
         ];


### PR DESCRIPTION
## Summary
- improve decoding logic to handle double-encoded UTF-8 characters
- always decode uploaded JSON and extract participant names

## Testing
- `npm run lint:check` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d91a19dc832f9062b13f8bde1dec